### PR TITLE
Fix cohort exploration loading state issue

### DIFF
--- a/src/state/exploredCohort.ts
+++ b/src/state/exploredCohort.ts
@@ -89,7 +89,7 @@ const fetchExploredCohort = createAsyncThunk<
         break
     }
   }
-  return { ...cohort } ?? state.exploredCohort
+  return cohort ?? state.exploredCohort
 })
 
 const exploredCohortSlice = createSlice({
@@ -112,7 +112,7 @@ const exploredCohortSlice = createSlice({
       state.requestId = meta.requestId
     })
     builder.addCase(fetchExploredCohort.fulfilled, (state, { payload, meta }) => {
-      return { ...payload, loading: state.requestId !== meta.requestId }
+      return { ...payload, cohortType: state.cohortType, loading: state.requestId !== meta.requestId }
     })
   }
 })


### PR DESCRIPTION
## Fixes

- cohort exploration loading state issue
- bug that resulted by hiding the whole `Répartition par périmètre` card from cohort exploration