### PR TITLE
Fix access request display condition issue

### DIFF
--- a/src/features/cohortes/CohortSelector.tsx
+++ b/src/features/cohortes/CohortSelector.tsx
@@ -66,19 +66,15 @@ const areCohortOrgaAccessRequestPendingSelector = createSelector(
   }
 )
 
-const showCreateAccessRequestAlertSelector = createSelector(
-  [cohortOrgaRepartitionDataSelector, orgaIdsOutOfPractitionerPerimeterSelector],
-  (orgaRepartitionData, orgaIdsOutOfPractitionerPerimeter) => {
-    if (orgaRepartitionData && orgaIdsOutOfPractitionerPerimeter) {
-      for (const { id: orgaId, value } of orgaRepartitionData) {
-        if (value > 0 && orgaId && orgaIdsOutOfPractitionerPerimeter.includes(orgaId)) {
-          return true
-        }
-      }
-    }
-    return false
-  }
-)
+const showCreateAccessRequestAlertSelector = createSelector(self, (state) => {
+  const { totalPatients, cohort } = state.exploredCohort
+  const cohortMembersCount = cohort?.member?.length
+
+  /*  If group members count differs from originalPatients count,
+   *  this means there are patients out of the practitioner's perimeter
+   */
+  return totalPatients !== cohortMembersCount
+})
 
 export {
   cohortOrgaRepartitionDataSelector,

--- a/src/features/cohortes/CohortSelector.tsx
+++ b/src/features/cohortes/CohortSelector.tsx
@@ -66,15 +66,24 @@ const areCohortOrgaAccessRequestPendingSelector = createSelector(
   }
 )
 
-const showCreateAccessRequestAlertSelector = createSelector(self, (state) => {
-  const { totalPatients, cohort } = state.exploredCohort
-  const cohortMembersCount = cohort?.member?.length
+const showCreateAccessRequestAlertSelector = createSelector(
+  [self, cohortOrgaRepartitionDataSelector, orgaIdsOutOfPractitionerPerimeterSelector],
+  (state, orgaRepartitionData, orgaIdsOutOfPractitionerPerimeter) => {
+    const { totalPatients, cohort } = state.exploredCohort
+    const cohortMembersCount = cohort?.member?.length
 
-  /*  If group members count differs from originalPatients count,
-   *  this means there are patients out of the practitioner's perimeter
-   */
-  return totalPatients !== cohortMembersCount
-})
+    if (orgaRepartitionData && orgaIdsOutOfPractitionerPerimeter) {
+      for (const { id: orgaId } of orgaRepartitionData) {
+        if (orgaId && orgaIdsOutOfPractitionerPerimeter.includes(orgaId)) {
+          /*  If group members count differs from originalPatients count,
+           *  this means there are patients out of the practitioner's perimeter */
+          return totalPatients !== cohortMembersCount
+        }
+      }
+    }
+    return false
+  }
+)
 
 export {
   cohortOrgaRepartitionDataSelector,

--- a/src/services/perimeters.ts
+++ b/src/services/perimeters.ts
@@ -143,9 +143,7 @@ export const fetchPerimetersInfos = async (perimeterIds: string[]): Promise<Coho
       agePyramidData,
       monthlyVisitData
     }
-  }
-
-  if (CONTEXT === 'arkhn') {
+  } else if (CONTEXT === 'arkhn') {
     const services = await getOrganizations(perimeterIds)
     const serviceIds = services.map((service) => service.id)
 

--- a/src/services/perimeters.ts
+++ b/src/services/perimeters.ts
@@ -14,7 +14,6 @@ import {
 import { getApiResponseResources } from 'utils/apiHelpers'
 
 import { CONTEXT } from '../constants'
-import { getLastEncounter } from './myPatients'
 import fakeGroup from '../data/fakeData/group'
 import fakeFacetDeceased from '../data/fakeData/facet-deceased'
 import fakeFacetAgeMonth from '../data/fakeData/facet-age-month'
@@ -86,64 +85,7 @@ export const fetchPerimetersInfos = async (perimeterIds: string[]): Promise<Coho
       monthlyVisitData
     }
   }
-  if (CONTEXT === 'aphp') {
-    const perimeterIdsJoined = perimeterIds.join(',')
-    const [perimetersResp, patientsResp, encountersResp] = await Promise.all([
-      api.get<FHIR_API_Response<IGroup>>(`/Group?_id=${perimeterIdsJoined}`),
-      api.get<FHIR_API_Response<IPatient>>(
-        `/Patient?pivotFacet=age_gender,deceased_gender&_list=${perimeterIdsJoined}&size=20&_sort=given&_elements=gender,name,birthDate,deceased,identifier,extension`
-      ),
-      api.get<FHIR_API_Response<IEncounter>>(
-        `/Encounter?pivotFacet=start-date_start-date-month_gender&facet=class&_list=${perimeterIdsJoined}&size=0&type=VISIT`
-      )
-    ])
-
-    const cohort = getApiResponseResources(perimetersResp)
-
-    const totalPatients = patientsResp?.data?.resourceType === 'Bundle' ? patientsResp.data.total : 0
-
-    const originalPatients = await getLastEncounter(getApiResponseResources(patientsResp))
-
-    const agePyramidData =
-      patientsResp?.data?.resourceType === 'Bundle'
-        ? getAgeRepartitionMapAphp(
-            patientsResp.data.meta?.extension?.filter((facet: any) => facet.url === 'facet-age-month')?.[0].extension
-          )
-        : undefined
-
-    const genderRepartitionMap =
-      patientsResp?.data?.resourceType === 'Bundle'
-        ? getGenderRepartitionMapAphp(
-            patientsResp.data.meta?.extension?.filter((facet: any) => facet.url === 'facet-deceased')?.[0].extension
-          )
-        : undefined
-
-    const monthlyVisitData =
-      encountersResp?.data?.resourceType === 'Bundle'
-        ? getVisitRepartitionMapAphp(
-            encountersResp.data.meta?.extension?.filter((facet: any) => facet.url === 'facet-start-date-facet')?.[0]
-              .extension
-          )
-        : undefined
-
-    const visitTypeRepartitionData =
-      encountersResp?.data?.resourceType === 'Bundle'
-        ? getEncounterRepartitionMapAphp(
-            encountersResp.data.meta?.extension?.filter((facet: any) => facet.url === 'facet-class-simple')?.[0]
-              .extension
-          )
-        : undefined
-
-    return {
-      cohort,
-      totalPatients,
-      originalPatients,
-      genderRepartitionMap,
-      visitTypeRepartitionData,
-      agePyramidData,
-      monthlyVisitData
-    }
-  } else if (CONTEXT === 'arkhn') {
+  if (CONTEXT === 'arkhn') {
     const services = await getOrganizations(perimeterIds)
     const serviceIds = services.map((service) => service.id)
 

--- a/src/state/exploredCohort.ts
+++ b/src/state/exploredCohort.ts
@@ -14,7 +14,6 @@ export type ExploredCohortState = {
 
 const initialState: ExploredCohortState = {
   name: '',
-  cohort: [],
   totalPatients: 0,
   originalPatients: [],
   totalDocs: 0,

--- a/src/types.ts
+++ b/src/types.ts
@@ -212,7 +212,7 @@ export type ComplexChartDataType<T, V = { [key: string]: number }> = Map<T, V>
 
 export type CohortData = {
   name?: string
-  cohort?: IGroup | IGroup[]
+  cohort?: IGroup
   totalPatients?: number
   originalPatients?: CohortPatient[]
   totalDocs?: number


### PR DESCRIPTION
## Description

In cohort exploration, when organizations are not in practitioner's perimeter : 
 - Changed the conditions set to determine whether we display the alert box containing the button or not.


## Technical details

Instead of working on the orga/patients repartition data, we compare the group members count with the number of patients in state (`originalPatients`)