### PR TITLE
Removed cache condition for cohort exploring

### DIFF
--- a/src/state/exploredCohort.ts
+++ b/src/state/exploredCohort.ts
@@ -39,6 +39,10 @@ const fetchExploredCohort = createAsyncThunk<
   const stateCohort = state.exploredCohort.cohort
   let shouldRefreshData = true
   switch (context) {
+    case 'cohort':
+      //FIXME: Cohort exploring cache removed for demo purposes
+      // shouldRefreshData = !stateCohort || Array.isArray(stateCohort) || stateCohort.id !== id
+      break
     case 'perimeters': {
       if (!id || !Array.isArray(id)) {
         throw new Error('No given perimeter ids')
@@ -57,7 +61,6 @@ const fetchExploredCohort = createAsyncThunk<
       break
     }
 
-    case 'cohort':
     default:
       break
   }

--- a/src/state/exploredCohort.ts
+++ b/src/state/exploredCohort.ts
@@ -40,7 +40,6 @@ const fetchExploredCohort = createAsyncThunk<
   let shouldRefreshData = true
   switch (context) {
     case 'cohort':
-      shouldRefreshData = !stateCohort || Array.isArray(stateCohort) || stateCohort.id !== id
       break
     case 'perimeters': {
       if (!id || !Array.isArray(id)) {

--- a/src/state/exploredCohort.ts
+++ b/src/state/exploredCohort.ts
@@ -39,8 +39,6 @@ const fetchExploredCohort = createAsyncThunk<
   const stateCohort = state.exploredCohort.cohort
   let shouldRefreshData = true
   switch (context) {
-    case 'cohort':
-      break
     case 'perimeters': {
       if (!id || !Array.isArray(id)) {
         throw new Error('No given perimeter ids')
@@ -59,6 +57,7 @@ const fetchExploredCohort = createAsyncThunk<
       break
     }
 
+    case 'cohort':
     default:
       break
   }


### PR DESCRIPTION
## Description

This removes the buggy behavior preventing a cohort to refresh its data if the user didn't change exploring subject (perimeter, patients, cohort,...)

## Fixes

- Fixes #39