### PR TITLE
Show cohort dashboard when members out of scope

### DIFF
--- a/src/features/cohortes/CohortSelector.tsx
+++ b/src/features/cohortes/CohortSelector.tsx
@@ -9,7 +9,16 @@ const cohortOrgaRepartitionDataSelector = createSelector(self, (state):
   | (SimpleChartDataType & { id?: string })[]
   | null => {
   const practitionerOrganizations = state.me?.organizations
-  const { perimeterRepartitionData } = state.exploredCohort
+  const { perimeterRepartitionData, originalPatients, cohort } = state.exploredCohort
+
+  const groupOrganizationsCount = cohort?.characteristic?.length ?? 0
+  const groupOrganizationsInPerimeterCount =
+    practitionerOrganizations?.filter((orga) => perimeterRepartitionData?.find(({ id }) => id === orga.id)).length ?? 0
+  const orgasOutOfPerimeterCount = groupOrganizationsCount - groupOrganizationsInPerimeterCount
+
+  const patientsInPerimeterCount = originalPatients?.length ?? 0
+  const cohortMembersCount = cohort?.member?.length ?? 0
+  const patientsOutOfPerimeterCount = cohortMembersCount - patientsInPerimeterCount
 
   if (!practitionerOrganizations || !perimeterRepartitionData) {
     return null
@@ -19,6 +28,7 @@ const cohortOrgaRepartitionDataSelector = createSelector(self, (state):
     const isOrgaInScope = practitionerOrganizations?.some((orga) => orga.id === data.id)
     return {
       ...data,
+      value: isOrgaInScope ? data.value : Math.floor(patientsOutOfPerimeterCount / orgasOutOfPerimeterCount),
       color: isOrgaInScope ? '#16BDFF' : '#777777'
     }
   })

--- a/src/features/cohortes/CohortSelector.tsx
+++ b/src/features/cohortes/CohortSelector.tsx
@@ -29,7 +29,7 @@ const cohortOrgaRepartitionDataSelector = createSelector(self, (state):
     return {
       ...data,
       value: isOrgaInScope ? data.value : Math.floor(patientsOutOfPerimeterCount / orgasOutOfPerimeterCount),
-      color: isOrgaInScope ? '#16BDFF' : '#BBBBBB'
+      color: isOrgaInScope ? '#16BDFF' : '#FFF4E5'
     }
   })
 })

--- a/src/features/cohortes/CohortSelector.tsx
+++ b/src/features/cohortes/CohortSelector.tsx
@@ -29,7 +29,7 @@ const cohortOrgaRepartitionDataSelector = createSelector(self, (state):
     return {
       ...data,
       value: isOrgaInScope ? data.value : Math.floor(patientsOutOfPerimeterCount / orgasOutOfPerimeterCount),
-      color: isOrgaInScope ? '#16BDFF' : '#777777'
+      color: isOrgaInScope ? '#16BDFF' : '#BBBBBB'
     }
   })
 })

--- a/src/features/cohortes/CohortSelector.tsx
+++ b/src/features/cohortes/CohortSelector.tsx
@@ -69,7 +69,8 @@ const areCohortOrgaAccessRequestPendingSelector = createSelector(
 const showCreateAccessRequestAlertSelector = createSelector(
   [self, cohortOrgaRepartitionDataSelector, orgaIdsOutOfPractitionerPerimeterSelector],
   (state, orgaRepartitionData, orgaIdsOutOfPractitionerPerimeter) => {
-    const { totalPatients, cohort } = state.exploredCohort
+    const { originalPatients, cohort } = state.exploredCohort
+    const patientsInPerimeterCount = originalPatients?.length
     const cohortMembersCount = cohort?.member?.length
 
     if (orgaRepartitionData && orgaIdsOutOfPractitionerPerimeter) {
@@ -77,7 +78,7 @@ const showCreateAccessRequestAlertSelector = createSelector(
         if (orgaId && orgaIdsOutOfPractitionerPerimeter.includes(orgaId)) {
           /*  If group members count differs from originalPatients count,
            *  this means there are patients out of the practitioner's perimeter */
-          return totalPatients !== cohortMembersCount
+          return patientsInPerimeterCount !== cohortMembersCount
         }
       }
     }

--- a/src/services/cohortInfos.ts
+++ b/src/services/cohortInfos.ts
@@ -173,7 +173,7 @@ const fetchCohort = async (cohortId: string | undefined): Promise<CohortData | u
 
       cohortResult.name = cohort?.name
       cohortResult.cohort = cohort
-      cohortResult.totalPatients = patients.length
+      cohortResult.totalPatients = cohort && cohort.member ? cohort.member.length : patients.length
       cohortResult.originalPatients = patients
       cohortResult.encounters = encounters
       cohortResult.genderRepartitionMap = getGenderRepartitionMap(patients)

--- a/src/services/cohortInfos.ts
+++ b/src/services/cohortInfos.ts
@@ -162,7 +162,7 @@ const fetchCohort = async (cohortId: string | undefined): Promise<CohortData | u
     const cohort = getApiResponseResources(groupResp)?.[0]
 
     if (cohort) {
-      const cohortOrganizationIds = (cohort?.characteristic
+      const cohortOrganizationIds = (cohort.characteristic
         ?.filter(({ valueReference }) => valueReference?.type === 'Organization')
         .map(({ valueReference }) => valueReference?.reference?.split('/')[1]) ?? []) as string[]
 
@@ -172,9 +172,9 @@ const fetchCohort = async (cohortId: string | undefined): Promise<CohortData | u
         (patientsAndEncounters?.filter((resource) => resource.resourceType === 'Encounter') as IEncounter[]) ?? []
       const organizations = await getOrganizations(cohortOrganizationIds)
 
-      cohortResult.name = cohort?.name
+      cohortResult.name = cohort.name
       cohortResult.cohort = cohort
-      cohortResult.totalPatients = cohort && cohort.member ? cohort.member.length : patients.length
+      cohortResult.totalPatients = cohort.member ? cohort.member.length : patients.length
       cohortResult.originalPatients = patients
       cohortResult.encounters = encounters
       cohortResult.genderRepartitionMap = getGenderRepartitionMap(patients)

--- a/src/services/cohortInfos.ts
+++ b/src/services/cohortInfos.ts
@@ -1,5 +1,3 @@
-import { head } from 'lodash'
-
 import api from './api'
 import apiBackCohort from './apiBackCohort'
 import { getInfos, getLastEncounter } from './myPatients'


### PR DESCRIPTION
## Description

Changes in the display behavior of a cohort dashboard :
- When no members are in the group (even though they're not in the practitioner's perimeter), the red alert still shows
- When there are members in and out of the group, display stays the same as before
- When there are group members and they're all out of the practitioner's perimeter, the dashboard shows as this :

<img width="1792" alt="Capture d’écran 2021-03-31 à 16 06 52" src="https://user-images.githubusercontent.com/12270309/113157379-20720080-923b-11eb-8dbe-81cdbc6d4c8b.png">


Regarding the dashboard displayed infos, one change is noticeable :
- The patients count (top left of the dashboard) now refers the `group.member` length, and not the api fetch patients count (which are filtered by perimeter)
