### PR TITLE
Change ordering in perimeter list

### DIFF
--- a/src/components/ScopeTree/ScopeTree.tsx
+++ b/src/components/ScopeTree/ScopeTree.tsx
@@ -40,6 +40,8 @@ const orderRowsByAccess = (rowA: ScopeTreeRow, rowB: ScopeTreeRow): number => {
     if (nameA > nameB) return 1
   } else if (rowA.access) {
     return -1
+  } else if (rowB.access) {
+    return 1
   }
 
   return 0

--- a/src/components/ScopeTree/ScopeTree.tsx
+++ b/src/components/ScopeTree/ScopeTree.tsx
@@ -38,13 +38,12 @@ const orderRowsByAccess = (rowA: ScopeTreeRow, rowB: ScopeTreeRow): number => {
 
     if (nameA < nameB) return -1
     if (nameA > nameB) return 1
+    return 0
   } else if (rowA.access) {
     return -1
-  } else if (rowB.access) {
+  } else {
     return 1
   }
-
-  return 0
 }
 
 const ScopeTree: React.FC<ScopeTreeProps> = ({

--- a/src/components/ScopeTree/ScopeTree.tsx
+++ b/src/components/ScopeTree/ScopeTree.tsx
@@ -31,6 +31,22 @@ type ScopeTreeProps = {
   restrictToPractitionerPerimeter?: boolean
 }
 
+const orderRowsByAccess = (rowA: ScopeTreeRow, rowB: ScopeTreeRow): number => {
+  if ((rowA.access && rowB.access) || (!rowA.access && !rowB.access)) {
+    const nameA = rowA.name
+    const nameB = rowB.name
+
+    if (nameA < nameB) return -1
+    if (nameA > nameB) return 1
+  } else {
+    if (rowA.access) {
+      return -1
+    }
+  }
+
+  return 0
+}
+
 const ScopeTree: React.FC<ScopeTreeProps> = ({
   defaultSelectedItems,
   onChangeSelectedItem,
@@ -40,7 +56,7 @@ const ScopeTree: React.FC<ScopeTreeProps> = ({
 
   const practitionerScopeRows = useAppSelector(practitionerScopeSelector)
   const [openPopulation, onChangeOpenPopulations] = useState<string[]>([])
-  const [rootRows, setRootRows] = useState<ScopeTreeRow[]>(practitionerScopeRows)
+  const [rootRows, setRootRows] = useState<ScopeTreeRow[]>(practitionerScopeRows.sort(orderRowsByAccess))
   const [loading, setLoading] = useState(false)
   const [selectedItems, setSelectedItem] = useState(defaultSelectedItems)
 
@@ -49,7 +65,7 @@ const ScopeTree: React.FC<ScopeTreeProps> = ({
       setLoading(true)
       getScopePerimeters(practitionerScopeRows.map(({ id }) => id))
         .then((rootRows) => {
-          setRootRows(rootRows)
+          setRootRows(rootRows.sort(orderRowsByAccess))
         })
         .finally(() => {
           setLoading(false)

--- a/src/components/ScopeTree/ScopeTree.tsx
+++ b/src/components/ScopeTree/ScopeTree.tsx
@@ -32,7 +32,7 @@ type ScopeTreeProps = {
 }
 
 const orderRowsByAccess = (rowA: ScopeTreeRow, rowB: ScopeTreeRow): number => {
-  if (rowA.access == rowB.access) {
+  if (rowA.access === rowB.access) {
     const nameA = rowA.name
     const nameB = rowB.name
 

--- a/src/components/ScopeTree/ScopeTree.tsx
+++ b/src/components/ScopeTree/ScopeTree.tsx
@@ -32,16 +32,14 @@ type ScopeTreeProps = {
 }
 
 const orderRowsByAccess = (rowA: ScopeTreeRow, rowB: ScopeTreeRow): number => {
-  if ((rowA.access && rowB.access) || (!rowA.access && !rowB.access)) {
+  if (rowA.access == rowB.access) {
     const nameA = rowA.name
     const nameB = rowB.name
 
     if (nameA < nameB) return -1
     if (nameA > nameB) return 1
-  } else {
-    if (rowA.access) {
-      return -1
-    }
+  } else if (rowA.access) {
+    return -1
   }
 
   return 0


### PR DESCRIPTION
## Fixes

- Fixes #52 

## Description

Sorted perimeter list first by access, then by alphabetically order.

<img width="1792" alt="Capture d’écran 2021-03-31 à 16 22 48" src="https://user-images.githubusercontent.com/12270309/113160482-d4748b00-923d-11eb-9968-dd5d9681c503.png">



