### PR TITLE
bug loosing isInclusive value on criteria change

### DIFF
--- a/src/state/cohortCreation.ts
+++ b/src/state/cohortCreation.ts
@@ -211,7 +211,7 @@ const cohortCreationSlice = createSlice({
     editSelectedCriteria: (state: CohortCreationState, action: PayloadAction<SelectedCriteriaType>) => {
       const foundItem = state.selectedCriteria.find(({ id }) => id === action.payload.id)
       const index = foundItem ? state.selectedCriteria.indexOf(foundItem) : -1
-      if (index !== -1) state.selectedCriteria[index] = action.payload
+      if (index !== -1) state.selectedCriteria[index] = { ...foundItem, ...action.payload }
     },
     editCriteriaGroup: (state: CohortCreationState, action: PayloadAction<CriteriaGroupType>) => {
       const foundItem = state.criteriaGroup.find(({ id }) => id === action.payload.id)


### PR DESCRIPTION
## Fixes

Fixes #82  by @MiskoG 

## Technical details

- When adding a criterion, `isInclusive` is set to `true` directly from the slice action.
- When updating it, the old criterion which had `isInclusive` value is overwritten by a newer one which doesn't have any `isInclusive` value and thus it is interpreted as false.

