### PR TITLE
Added snackbar in AccessRequests component

### DIFF
--- a/src/features/access/RequestItem.tsx
+++ b/src/features/access/RequestItem.tsx
@@ -4,6 +4,7 @@ import moment from 'moment'
 
 import { IPractitionerRole } from '@ahryman40k/ts-fhir-types/lib/R4'
 import { Grid, makeStyles, MenuItem, Select, Typography } from '@material-ui/core'
+import { unwrapResult } from '@reduxjs/toolkit'
 
 import { PERMISSION_STATUS_STRUCTURE_DEF_URL } from '../../constants'
 import { updateAccessRequest } from './AccessRequestSlice'
@@ -44,9 +45,10 @@ const useStyles = makeStyles((theme) => ({
 
 type RequestItemProps = {
   request: AccessRequest
+  onSubmitSuccess?: (isRejected?: boolean) => void
 }
 
-const RequestItem = ({ request }: RequestItemProps) => {
+const RequestItem = ({ request, onSubmitSuccess }: RequestItemProps) => {
   const classes = useStyles()
   const dispatch = useAppDispatch()
   const [nominativeAccess, setNominativeAccess] = useState<'yes' | 'no'>('yes')
@@ -78,6 +80,10 @@ const RequestItem = ({ request }: RequestItemProps) => {
           }
     }
     dispatch(updateAccessRequest(practitionerRole))
+      .then(unwrapResult)
+      .then(() => {
+        onSubmitSuccess && onSubmitSuccess(isRejected)
+      })
   }
 
   return (

--- a/src/features/access/RequestItem.tsx
+++ b/src/features/access/RequestItem.tsx
@@ -46,9 +46,10 @@ const useStyles = makeStyles((theme) => ({
 type RequestItemProps = {
   request: AccessRequest
   onSubmitSuccess?: (isRejected?: boolean) => void
+  onSubmitError?: () => void
 }
 
-const RequestItem = ({ request, onSubmitSuccess }: RequestItemProps) => {
+const RequestItem = ({ request, onSubmitSuccess, onSubmitError }: RequestItemProps) => {
   const classes = useStyles()
   const dispatch = useAppDispatch()
   const [nominativeAccess, setNominativeAccess] = useState<'yes' | 'no'>('yes')
@@ -83,6 +84,9 @@ const RequestItem = ({ request, onSubmitSuccess }: RequestItemProps) => {
       .then(unwrapResult)
       .then(() => {
         onSubmitSuccess && onSubmitSuccess(isRejected)
+      })
+      .catch(() => {
+        onSubmitError && onSubmitError()
       })
   }
 

--- a/src/views/AccessRequests/AccessRequests.tsx
+++ b/src/views/AccessRequests/AccessRequests.tsx
@@ -12,7 +12,7 @@ import { accessRequestsSelector } from 'features/access/RequestSelector'
 
 const AccessRequests = () => {
   const classes = useStyles()
-  const [snackbarState, setSnackbarState] = useState<{ error?: boolean; message?: string }>({})
+  const [snackbarMessage, setSnackbarMessage] = useState<string | null>(null)
   const dispatch = useAppDispatch()
   const { open, requests } = useAppSelector((state) => ({
     open: state.drawer,
@@ -20,13 +20,10 @@ const AccessRequests = () => {
   }))
 
   const handleCloseSnackbar = () => {
-    setSnackbarState({})
+    setSnackbarMessage(null)
   }
-  const handleRequestSuccess = (isRejected?: boolean) => {
-    setSnackbarState({
-      error: isRejected,
-      message: isRejected ? `Demande d'accès refusée` : `Demande d'accès acceptée`
-    })
+  const handleRequestSuccess = () => {
+    setSnackbarMessage(`Votre réponse a bien été prise en compte`)
   }
 
   useEffect(() => {
@@ -40,13 +37,13 @@ const AccessRequests = () => {
       })}
     >
       <Snackbar
-        open={!!snackbarState.message}
+        open={!!snackbarMessage}
         anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
         autoHideDuration={6000}
         onClose={handleCloseSnackbar}
       >
-        <Alert onClose={handleCloseSnackbar} severity={snackbarState.error ? 'error' : 'success'}>
-          {snackbarState.message}
+        <Alert onClose={handleCloseSnackbar} severity={'success'}>
+          {snackbarMessage}
         </Alert>
       </Snackbar>
       <Grid container direction="column" spacing={6}>

--- a/src/views/AccessRequests/AccessRequests.tsx
+++ b/src/views/AccessRequests/AccessRequests.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import clsx from 'clsx'
 
-import { Container, Divider, Grid, Paper, Typography } from '@material-ui/core'
+import { Container, Divider, Grid, Paper, Typography, Snackbar } from '@material-ui/core'
+import { Alert } from '@material-ui/lab'
 
 import RequestItem from 'features/access/RequestItem'
 import useStyles from './styles'
@@ -11,11 +12,22 @@ import { accessRequestsSelector } from 'features/access/RequestSelector'
 
 const AccessRequests = () => {
   const classes = useStyles()
+  const [snackbarState, setSnackbarState] = useState<{ error?: boolean; message?: string }>({})
   const dispatch = useAppDispatch()
   const { open, requests } = useAppSelector((state) => ({
     open: state.drawer,
     requests: accessRequestsSelector(state)
   }))
+
+  const handleCloseSnackbar = () => {
+    setSnackbarState({})
+  }
+  const handleRequestSuccess = (isRejected?: boolean) => {
+    setSnackbarState({
+      error: isRejected,
+      message: isRejected ? `Demande d'accès refusée` : `Demande d'accès acceptée`
+    })
+  }
 
   useEffect(() => {
     dispatch(fetchAccessRequests())
@@ -27,6 +39,16 @@ const AccessRequests = () => {
         [classes.appBarShift]: open
       })}
     >
+      <Snackbar
+        open={!!snackbarState.message}
+        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+        autoHideDuration={6000}
+        onClose={handleCloseSnackbar}
+      >
+        <Alert onClose={handleCloseSnackbar} severity={snackbarState.error ? 'error' : 'success'}>
+          {snackbarState.message}
+        </Alert>
+      </Snackbar>
       <Grid container direction="column" spacing={6}>
         <Grid item>
           <Typography variant="h1">Demandes d'accès</Typography>
@@ -45,7 +67,7 @@ const AccessRequests = () => {
                 requests.map((request) => (
                   <Grid item key={request.id}>
                     <Divider />
-                    <RequestItem request={request} />
+                    <RequestItem onSubmitSuccess={handleRequestSuccess} request={request} />
                   </Grid>
                 ))
               )}

--- a/src/views/AccessRequests/AccessRequests.tsx
+++ b/src/views/AccessRequests/AccessRequests.tsx
@@ -12,7 +12,7 @@ import { accessRequestsSelector } from 'features/access/RequestSelector'
 
 const AccessRequests = () => {
   const classes = useStyles()
-  const [snackbarMessage, setSnackbarMessage] = useState<string | null>(null)
+  const [snackbarState, setSnackbarState] = useState<{ message?: string; error?: boolean }>({})
   const dispatch = useAppDispatch()
   const { open, requests } = useAppSelector((state) => ({
     open: state.drawer,
@@ -20,10 +20,16 @@ const AccessRequests = () => {
   }))
 
   const handleCloseSnackbar = () => {
-    setSnackbarMessage(null)
+    setSnackbarState({})
   }
   const handleRequestSuccess = () => {
-    setSnackbarMessage(`Votre réponse a bien été prise en compte`)
+    setSnackbarState({ error: false, message: `Votre réponse a bien été prise en compte` })
+  }
+  const handleRequestError = () => {
+    setSnackbarState({
+      error: true,
+      message: `Une erreur est survenue. Votre réponse n'a pas pu être prise en compte.`
+    })
   }
 
   useEffect(() => {
@@ -37,13 +43,13 @@ const AccessRequests = () => {
       })}
     >
       <Snackbar
-        open={!!snackbarMessage}
+        open={!!snackbarState.message}
         anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
         autoHideDuration={6000}
         onClose={handleCloseSnackbar}
       >
-        <Alert onClose={handleCloseSnackbar} severity={'success'}>
-          {snackbarMessage}
+        <Alert onClose={handleCloseSnackbar} severity={snackbarState.error ? 'error' : 'success'}>
+          {snackbarState.message}
         </Alert>
       </Snackbar>
       <Grid container direction="column" spacing={6}>
@@ -64,7 +70,11 @@ const AccessRequests = () => {
                 requests.map((request) => (
                   <Grid item key={request.id}>
                     <Divider />
-                    <RequestItem onSubmitSuccess={handleRequestSuccess} request={request} />
+                    <RequestItem
+                      onSubmitSuccess={handleRequestSuccess}
+                      onSubmitError={handleRequestError}
+                      request={request}
+                    />
                   </Grid>
                 ))
               )}


### PR DESCRIPTION
## Fixes

Fixes #80 by @MiskoG 

## Description

- Use of material-ui `Snackbar` component
- Handle access updates and failures with severities respectively `success` & `error` 

## Screenshots

<img width="1792" alt="Capture d’écran 2021-04-13 à 11 17 35" src="https://user-images.githubusercontent.com/12270309/114529283-1512d200-9c4a-11eb-8c86-1d66ff10ace8.png">
<img width="1792" alt="Capture d’écran 2021-04-13 à 11 25 28" src="https://user-images.githubusercontent.com/12270309/114530281-17296080-9c4b-11eb-8633-be152b6bbfbe.png">
